### PR TITLE
Treat invalid strings as empty

### DIFF
--- a/smbios/smbios.go
+++ b/smbios/smbios.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/digitalocean/go-smbios/smbios"
 )
@@ -153,6 +154,11 @@ func GetStringOrEmpty(s *smbios.Structure, offset int) string {
 
 	str := s.Strings[index-1]
 	trimmed := strings.TrimSpace(str)
+
+	// Do not pass on invalid UTF8 strings as this can blow up grpc
+	if !utf8.ValidString(trimmed) {
+		return _Empty
+	}
 
 	// Convert to lowercase to address multiple formats:
 	//   - "To Be Filled By O.E.M."


### PR DESCRIPTION
Unprintable strings are likely of no use.  This change allows for the filtering of non utf8 strings that users of this library may not be expecting.  Additionally this MR uses the new golangci-lint installation path.

I specifically needed this or a similar change due to the SMBios of my Intel NUCs having invalid characters in most of the system information fields (good info is in the baseboard fields).  This was causing issues with the downstream sidero metal server registration gRPC API.