### PR TITLE
fix(memory): fix MemoryDeviceExtendedSize type

### DIFF
--- a/smbios/memory_device.go
+++ b/smbios/memory_device.go
@@ -229,7 +229,7 @@ func (m MemoryDeviceSize) String() string {
 }
 
 // MemoryDeviceExtendedSize represents the SMBIOS memory device extended size.
-type MemoryDeviceExtendedSize uint16
+type MemoryDeviceExtendedSize uint32
 
 // String returns the string representation of the SMBIOS memory device extended size.
 func (m MemoryDeviceExtendedSize) String() string {


### PR DESCRIPTION
change MemoryDeviceExtendedSize to type uint32; uint16 must be 0, if memroy is 64GiB